### PR TITLE
質問一覧を表示可能に

### DIFF
--- a/App/SwapWithMe.xcodeproj/project.pbxproj
+++ b/App/SwapWithMe.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		D45CA13D2A5929EE00C787D6 /* SignUp in Frameworks */ = {isa = PBXBuildFile; productRef = D45CA13C2A5929EE00C787D6 /* SignUp */; };
 		D45CA13F2A597C3E00C787D6 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = D45CA13E2A597C3E00C787D6 /* GoogleService-Info.plist */; };
 		D4A1F78D2A5EF80B0053DB95 /* ViewComponents in Frameworks */ = {isa = PBXBuildFile; productRef = D4A1F78C2A5EF80B0053DB95 /* ViewComponents */; };
+		D4B2E5712A78038800E5850E /* QuestionList in Frameworks */ = {isa = PBXBuildFile; productRef = D4B2E5702A78038800E5850E /* QuestionList */; };
 		D4BC152D2A6999000029787F /* UserInfo in Frameworks */ = {isa = PBXBuildFile; productRef = D4BC152C2A6999000029787F /* UserInfo */; };
 /* End PBXBuildFile section */
 
@@ -58,6 +59,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D4B2E5712A78038800E5850E /* QuestionList in Frameworks */,
 				D45CA13D2A5929EE00C787D6 /* SignUp in Frameworks */,
 				D4433AA92A6F8F3A000FA106 /* Home in Frameworks */,
 				D4BC152D2A6999000029787F /* UserInfo in Frameworks */,
@@ -88,9 +90,9 @@
 				D431A89E2A4848EE00109710 /* SwapWithMe */,
 				D431A8AF2A4848EF00109710 /* SwapWithMeTests */,
 				D431A8B92A4848EF00109710 /* SwapWithMeUITests */,
-				D4BB2BE42A543271007C9ADB /* SwapWithMe */,
 				D431A89D2A4848EE00109710 /* Products */,
 				D44C3A7D2A543AC700A634F1 /* Frameworks */,
+				D4BB2BE42A543271007C9ADB /* SwapWithMe */,
 			);
 			sourceTree = "<group>";
 		};
@@ -171,6 +173,7 @@
 				D4A1F78C2A5EF80B0053DB95 /* ViewComponents */,
 				D4BC152C2A6999000029787F /* UserInfo */,
 				D4433AA82A6F8F3A000FA106 /* Home */,
+				D4B2E5702A78038800E5850E /* QuestionList */,
 			);
 			productName = SwapWithMe;
 			productReference = D431A89C2A4848EE00109710 /* SwapWithMe.app */;
@@ -654,6 +657,10 @@
 		D4A1F78C2A5EF80B0053DB95 /* ViewComponents */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = ViewComponents;
+		};
+		D4B2E5702A78038800E5850E /* QuestionList */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = QuestionList;
 		};
 		D4BC152C2A6999000029787F /* UserInfo */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/Package.swift
+++ b/Package.swift
@@ -64,6 +64,7 @@ let featureTargets: [Target] = [
     ]),
     .feature(name: "Home", dependencies: [
         "ViewComponents",
+        "QuestionList",
         readabilityModifier,
         popupView,
     ]),

--- a/Package.swift
+++ b/Package.swift
@@ -66,6 +66,11 @@ let featureTargets: [Target] = [
         "ViewComponents",
         readabilityModifier,
         popupView,
+    ]),
+    .feature(name: "QuestionList", dependencies: [
+        "ViewComponents",
+        readabilityModifier,
+        popupView,
     ])
 ]
 
@@ -117,6 +122,15 @@ let package = Package(
                 popupView,
             ],
             path: "Sources/Feature/Home"
+        ),
+        .target(
+            name: "QuestionList",
+            dependencies: [
+                "ViewComponents",
+                readabilityModifier,
+                popupView,
+            ],
+            path: "Sources/Feature/QuestionList"
         )
     ]
 )

--- a/Sources/Core/ViewComponents/SwapedPopup.swift
+++ b/Sources/Core/ViewComponents/SwapedPopup.swift
@@ -11,9 +11,11 @@ public struct SwapedPopup: View {
     @State private var myCardImage = Image(uiImage: UIImage())
     @State private var partnerCardImage = Image(uiImage: UIImage())
     var isQuestionPopup: Binding<Bool>
+    var isTransQuestionList: Binding<Bool>
 
-    public init(isQuestionPopup: Binding<Bool>) {
+    public init(isQuestionPopup: Binding<Bool>, isTransQuestionList: Binding<Bool>) {
         self.isQuestionPopup = isQuestionPopup
+        self.isTransQuestionList = isTransQuestionList
     }
 
     public var body: some View {
@@ -47,7 +49,7 @@ public struct SwapedPopup: View {
             VStack(spacing: 0) {
                 Button(
                     action: {
-                        print("質問画面へ遷移")
+                        isTransQuestionList.wrappedValue = true
                     },
                     label: {
                         toQuestionButtonText()
@@ -101,6 +103,6 @@ public struct SwapedPopup: View {
 
 struct SwapedPopup_Previews: PreviewProvider {
     static var previews: some View {
-        SwapedPopup(isQuestionPopup: .constant(true))
+        SwapedPopup(isQuestionPopup: .constant(true), isTransQuestionList: .constant(true))
     }
 }

--- a/Sources/Feature/Home/HomeView.swift
+++ b/Sources/Feature/Home/HomeView.swift
@@ -7,6 +7,7 @@
 
 import AudioToolbox
 import PopupView
+import QuestionList
 import ReadabilityModifier
 import SwiftUI
 import ViewComponents
@@ -20,6 +21,7 @@ public struct HomeView: View {
     @State private var swapImagesOpacity = [0.0, 0.0, 0.0]
     @State private var userInfoOpacity = 0.0
     @State private var isQuestionPopup = false
+    @State private var isTransQuestionList = false
 
     private let swapIconSize = CGSize(width: 1527 / 7, height: 522 / 7)
     private let swapTimer = Timer.publish(every: 0.2, on: .main, in: .common).autoconnect()
@@ -47,12 +49,19 @@ public struct HomeView: View {
                 myInfo(name: "きよはらしょうう", age: 25, affiliation: "人見知り")
                     .offset(x: 0, y: (250 * 0.6) - 12)
             }
+
+            NavigationLink(
+                destination: QuestionListView(),
+                isActive: $isTransQuestionList
+            ) {
+                EmptyView()
+            }
         }
         .fitToReadableContentGuide()
         .popup(
             isPresented: $isQuestionPopup
         ) {
-            SwapedPopup(isQuestionPopup: $isQuestionPopup)
+            SwapedPopup(isQuestionPopup: $isQuestionPopup, isTransQuestionList: $isTransQuestionList)
         } customize: {
             $0
                 .type(.default)

--- a/Sources/Feature/QuestionList/QuestionListView.swift
+++ b/Sources/Feature/QuestionList/QuestionListView.swift
@@ -13,19 +13,21 @@ public struct QuestionListView: View {
     public init() {}
 
     public var body: some View {
-        VStack(alignment: .leading, spacing: 12) {
-            Text("趣味についての質問")
-                .font(.system(size: 24, weight: .bold, design: .rounded))
-                .foregroundColor(.green)
+        VStack(spacing: 32) {
+            questionText(questionNum: 1)
+        }
+        .fitToReadableContentGuide()
+    }
 
-            Text("好きなサッカーチームは？")
+    private func questionText(questionNum: Int) -> some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Q\(questionNum) : 好きなサッカーチームは？")
                 .font(.system(size: 18, weight: .semibold, design: .rounded))
 
             Text("2人ともサッカーが好きという共通点があります。このことから好きなサッカーチームについて話をするのが良いと思います。")
                 .font(.system(size: 16, weight: .regular, design: .rounded))
                 .foregroundColor(.gray)
         }
-        .fitToReadableContentGuide()
     }
 }
 

--- a/Sources/Feature/QuestionList/QuestionListView.swift
+++ b/Sources/Feature/QuestionList/QuestionListView.swift
@@ -9,14 +9,58 @@ import ReadabilityModifier
 import SwiftUI
 
 public struct QuestionListView: View {
+    @State var cardImage: Image = Image(uiImage: UIImage())
 
     public init() {}
 
     public var body: some View {
         VStack(spacing: 32) {
+            ZStack {
+                card()
+                partnerInfo(name: "ながのめいですす", age: 24, affiliation: "フレンドリー")
+                    .offset(x: 0, y: 400 * 0.7 * 0.25)
+            }
             questionText(questionNum: 1)
         }
         .fitToReadableContentGuide()
+        .onAppear {
+            cardImage = Image("nagano")
+        }
+    }
+
+    private func card() -> some View {
+        ZStack {
+            cardImage
+                .resizable()
+                .scaledToFill()
+
+            LinearGradient(
+                gradient: Gradient(colors: [.clear, .black.opacity(0.7)]),
+                startPoint: .top,
+                endPoint: .bottom
+            )
+        }
+        .frame(width: 250 * 0.7, height: 400 * 0.7)
+        .cornerRadius(20)
+        .overlay(
+            RoundedRectangle(cornerRadius: 20)
+                .stroke(Color.green, lineWidth: 4)
+        )
+    }
+
+    private func partnerInfo(name: String, age: Int, affiliation: String) -> some View {
+        VStack(spacing: 6) {
+            Text("\(name)")
+                .font(.system(size: 18, weight: .bold, design: .rounded))
+
+            HStack(spacing: 6) {
+                Text("\(age)歳")
+
+                Text("\(affiliation)")
+            }
+            .font(.system(size: 12, weight: .medium, design: .rounded))
+        }
+        .foregroundColor(.white)
     }
 
     private func questionText(questionNum: Int) -> some View {

--- a/Sources/Feature/QuestionList/QuestionListView.swift
+++ b/Sources/Feature/QuestionList/QuestionListView.swift
@@ -21,6 +21,14 @@ public struct QuestionListView: View {
                     .offset(x: 0, y: 400 * 0.7 * 0.25)
             }
             questionText(questionNum: 1)
+            questionText(questionNum: 2)
+            questionText(questionNum: 3)
+            questionText(questionNum: 4)
+            questionText(questionNum: 5)
+            questionText(questionNum: 6)
+            questionText(questionNum: 7)
+            questionText(questionNum: 8)
+            questionText(questionNum: 9)
         }
         .fitToReadableContentGuide()
         .onAppear {

--- a/Sources/Feature/QuestionList/QuestionListView.swift
+++ b/Sources/Feature/QuestionList/QuestionListView.swift
@@ -14,23 +14,25 @@ public struct QuestionListView: View {
     public init() {}
 
     public var body: some View {
-        VStack(spacing: 32) {
-            ZStack {
-                card()
-                partnerInfo(name: "ながのめいですす", age: 24, affiliation: "フレンドリー")
-                    .offset(x: 0, y: 400 * 0.7 * 0.25)
+        ScrollView {
+            VStack(spacing: 32) {
+                ZStack {
+                    card()
+                    partnerInfo(name: "ながのめいですす", age: 24, affiliation: "フレンドリー")
+                        .offset(x: 0, y: 400 * 0.7 * 0.25)
+                }
+                questionText(questionNum: 1)
+                questionText(questionNum: 2)
+                questionText(questionNum: 3)
+                questionText(questionNum: 4)
+                questionText(questionNum: 5)
+                questionText(questionNum: 6)
+                questionText(questionNum: 7)
+                questionText(questionNum: 8)
+                questionText(questionNum: 9)
             }
-            questionText(questionNum: 1)
-            questionText(questionNum: 2)
-            questionText(questionNum: 3)
-            questionText(questionNum: 4)
-            questionText(questionNum: 5)
-            questionText(questionNum: 6)
-            questionText(questionNum: 7)
-            questionText(questionNum: 8)
-            questionText(questionNum: 9)
+            .fitToReadableContentGuide()
         }
-        .fitToReadableContentGuide()
         .onAppear {
             cardImage = Image("nagano")
         }

--- a/Sources/Feature/QuestionList/QuestionListView.swift
+++ b/Sources/Feature/QuestionList/QuestionListView.swift
@@ -1,0 +1,36 @@
+//
+//  QuestionListView.swift
+//
+//
+//  Created by 濵田　悠樹 on 2023/07/31.
+//
+
+import ReadabilityModifier
+import SwiftUI
+
+public struct QuestionListView: View {
+
+    public init() {}
+
+    public var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("趣味についての質問")
+                .font(.system(size: 24, weight: .bold, design: .rounded))
+                .foregroundColor(.green)
+
+            Text("好きなサッカーチームは？")
+                .font(.system(size: 18, weight: .semibold, design: .rounded))
+
+            Text("2人ともサッカーが好きという共通点があります。このことから好きなサッカーチームについて話をするのが良いと思います。")
+                .font(.system(size: 16, weight: .regular, design: .rounded))
+                .foregroundColor(.gray)
+        }
+        .fitToReadableContentGuide()
+    }
+}
+
+struct QuestionListView_Previews: PreviewProvider {
+    static var previews: some View {
+        QuestionListView()
+    }
+}


### PR DESCRIPTION
## 概要(1言で簡潔に)

カードをSwapした相手との質問を表示可能にする


## 詳細

- 現段階で文章は決めうち
- 本来はChatGPTを使って質問文を決める


## UI

| 質問一覧 | GIF |
| --- | --- |
| <img width = 300 src = "https://github.com/hamadayuuki/SwapWithMe/assets/55442055/412f72fd-93c1-4d85-a753-107696713903"> | <img width = 300 src = "https://github.com/hamadayuuki/SwapWithMe/assets/55442055/18ea7b80-23c2-4e8b-b9af-b22f0a78516e"> |

