### PR TITLE
Swift DependenciesMacro を導入し DIのコードを簡略化

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,7 @@ let packageDependencies: [PackageDependency] = [
     .package(url: "https://github.com/yazio/ReadabilityModifier", from: .init(1, 0, 0)),
     .package(url: "https://github.com/exyte/PopupView", from: .init(2, 5, 7)),
     .package(url: "https://github.com/pointfreeco/swift-composable-architecture", from: .init(1, 2, 0)),
-    .package(url: "https://github.com/pointfreeco/swift-dependencies", from: .init(1, 0, 0)),
+    .package(url: "https://github.com/pointfreeco/swift-dependencies", from: .init(1, 1, 0)),
     .package(url: "https://github.com/TimOliver/TOCropViewController.git", from: .init(2, 6, 1)),
     .package(url: "https://github.com/kean/Nuke.git", from: .init(12, 1, 5))
 ]
@@ -29,6 +29,7 @@ let fireStorage: TargetDependency = .product(name: "FirebaseStorage", package: "
 let popupView: TargetDependency = .product(name: "PopupView", package: "PopupView")
 let composableArchitecture: TargetDependency = .product(name: "ComposableArchitecture", package: "swift-composable-architecture")
 let dependencies: TargetDependency = .product(name: "Dependencies", package: "swift-dependencies")
+let dependenciesMacros: TargetDependency = .product(name: "DependenciesMacros", package: "swift-dependencies")
 let cropViewController: TargetDependency = .product(name: "CropViewController", package: "TOCropViewController")
 let nuke: TargetDependency = .product(name: "Nuke", package: "Nuke")
 
@@ -74,6 +75,7 @@ let coreTargets: [Target] = [
     .core(name: "Error", dependencies: []),
     .core(name: "Routing", dependencies: [
         dependencies,
+        dependenciesMacros,
     ])
 ]
 

--- a/README.md
+++ b/README.md
@@ -176,6 +176,8 @@ Workflow は以下の通り。2つのScriptはそれぞれ `brew install mint`, 
 
 <img width = 200 src = "https://github.com/hamadayuuki/SwapWithMe/assets/55442055/be56e1c8-3d69-40bf-8cd6-b979b662b2eb">
 
+`追記(2024/2/7)` : 2つのScript後 に Scriptを追加 しています。追加したScriptは `defaults write com.apple.dt.Xcode IDESkipMacroFingerprintValidation -bool YES` で、追加理由は Macros をCI上で使用するためにCompiler Pluginの実行許可することです。
+
 
 ## 実行環境設定
 

--- a/Sources/Core/Routing/Dependencies/ViewBuildingClient.swift
+++ b/Sources/Core/Routing/Dependencies/ViewBuildingClient.swift
@@ -9,22 +9,16 @@ import Dependencies
 import DependenciesMacros
 import SwiftUI
 
+@DependencyClient
 public struct ViewBuildingClient {
-    public var questionListView: @Sendable (_ cardImage: Image) -> AnyView
-
-    public init(
-        questionListView: @escaping @Sendable (Image) -> AnyView
-    ) {
-        self.questionListView = questionListView
-    }
+    // Test でunimplemented()を使用するためデフォルト値が必要なため "= {}"を追加している
+    public var questionListView: @Sendable (_ cardImage: Image) -> AnyView = { _ in AnyView(EmptyView()) }
 }
 
 // MARK: - Dependnecies
 
 extension ViewBuildingClient: TestDependencyKey {
-    public static let testValue: ViewBuildingClient = .init(
-        questionListView: unimplemented()
-    )
+    public static let testValue = Self()
 }
 
 extension DependencyValues {

--- a/Sources/Core/Routing/Dependencies/ViewBuildingClient.swift
+++ b/Sources/Core/Routing/Dependencies/ViewBuildingClient.swift
@@ -6,6 +6,7 @@
 //
 
 import Dependencies
+import DependenciesMacros
 import SwiftUI
 
 public struct ViewBuildingClient {


### PR DESCRIPTION
## 概要(1言で簡潔に)

Macros を用いてコードを簡略化する

## 詳細

swift-dependencies@1.1〜 で[使用可能となった](https://github.com/pointfreeco/swift-dependencies/pull/132) DependenciesMacros を用いる。

## 変更点

```diff
// Package.swift

~
+     .package(url: "https://github.com/pointfreeco/swift-dependencies", from: .init(1, 1, 0)),
~
+ let dependenciesMacros: TargetDependency = .product(name: "DependenciesMacros", package: "swift-dependencies")
~
```

```diff
// ViewBuildingClient.swift

import Dependencies
+import DependenciesMacros
import SwiftUI

+@DependencyClient
public struct ViewBuildingClient {
+    // Test でunimplemented()を使用するためデフォルト値が必要なため "= {}"を追加している
+    public var questionListView: @Sendable (_ cardImage: Image) -> AnyView = { _ in AnyView(EmptyView()) }

-    public var questionListView: @Sendable (_ cardImage: Image) -> AnyView
-
-    public init(
-        questionListView: @escaping @Sendable (Image) -> AnyView
-    ) {
-       self.questionListView = questionListView
-    }
}

// MARK: - Dependnecies

extension ViewBuildingClient: TestDependencyKey {
+    public static let testValue = Self()

-    public static let testValue: ViewBuildingClient = .init(
-       questionListView: unimplemented()
-    )
}
```